### PR TITLE
Allow broccoli-plugin subclasses to be tested with mock-fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var ReadCompat;
+
 module.exports = Plugin
 function Plugin(inputNodes, options) {
   if (!(this instanceof Plugin)) throw new Error('Missing `new` operator')
@@ -116,6 +118,14 @@ Plugin.prototype.cleanup = function() {
 }
 
 Plugin.prototype._initializeReadCompat = function() {
-  var ReadCompat = require('./read_compat')
+  if (ReadCompat === void 0) ReadCompat = require('./read_compat')
   this._readCompat = new ReadCompat(this)
+}
+
+// Static method which enables requiring normally optional modules at a
+// predictable time. May be necessary when using rewire to mock native
+// modules.
+Plugin.initialize = function() {
+  if (ReadCompat === void 0) ReadCompat = require('./read_compat')
+  return this
 }


### PR DESCRIPTION
This patch enables broccoli-plugin to predictably require()
./read_compat (or any files needed in the future) at a specific time,
before the module actually needs to be run.

By default, the files are still loaded on demand, maintaining the
same performance and semantics as are currently checked into the tree.

Still missing tests, and blocked on https://github.com/tschaub/mock-fs/pull/56 (at least, for my uses)
