### PR TITLE
package.json: Whitelist JS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "https://github.com/broccolijs/broccoli-plugin"
   },
+  "files": [
+    "index.js",
+    "read_compat.js"
+  ],
   "keywords": [
     "broccoli-plugin"
   ],


### PR DESCRIPTION
This prevents "tmp/" from ending up on NPM again inside the package. Resolves #13 

/cc @stefanpenner 