### PR TITLE
Stable 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # master
 
+# 1.2.2
+
+* Whitelist JS files in package.json
+* re-release without tmp/
+
 # 1.2.1
 
 * Throw error immediately when inputNodes contains something other than input nodes

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "https://github.com/broccolijs/broccoli-plugin"
   },
+  "files": [
+    "index.js",
+    "read_compat.js"
+  ],
   "keywords": [
     "broccoli-plugin"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broccoli-plugin",
   "description": "Base class for all Broccoli plugins",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Jo Liss <joliss42@gmail.com>",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
I've created a 1.x stable branch, so that we can re-publish 1.2.1 without `tmp` and with the files whitelist.

This PR exists as a way to make sure me and @joliss sync up, and are both aware of this.

cc @joliss 