### PR TITLE
Avoid creating a directory for nesting if not needed.

### DIFF
--- a/read_compat.js
+++ b/read_compat.js
@@ -19,8 +19,13 @@ function ReadCompat(plugin) {
   quickTemp.makeOrReuse(this, 'inputBasePath', this.pluginInterface.name)
 
   this.inputPaths = []
-  for (var i = 0; i < this.pluginInterface.inputNodes.length; i++) {
-    this.inputPaths.push(path.join(this.inputBasePath, i + ''))
+
+  if (this.pluginInterface.inputNodes.length === 1) {
+    this.inputPaths.push(this.inputBasePath)
+  } else {
+    for (var i = 0; i < this.pluginInterface.inputNodes.length; i++) {
+      this.inputPaths.push(path.join(this.inputBasePath, i + ''))
+    }
   }
 
   this.pluginInterface.setup(null, {


### PR DESCRIPTION
When only a single input node is present, there is no need to create a parent directory with a single directory in it. Instead, just create the single directory that we need and use it.