### PR TITLE
Enable plugins to avoid creating cache path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Call this base class constructor from your subclass constructor.
       multiple instances of the same plugin apart.
     * `persistentOutput`: If true, the output directory is not automatically
       emptied between builds.
+    * `createCacheDirectory` : If `true`, a cache directory is created automatically
+      and the path is set at `cachePath`. If `false`, a cache directory is not created
+      and `this.cachePath` is `undefined`. Defaults to `true`.
 
 ### `Plugin.prototype.build()`
 
@@ -66,7 +69,8 @@ This function will typically access the following read-only properties:
 
 * `this.cachePath`: The path on disk to an auxiliary cache directory. Use this
   to store files that you want preserved between builds. This directory will
-  only be deleted when Broccoli exits.
+  only be deleted when Broccoli exits. If a cache directory is not needed, set
+  `createCacheDirectory` to `false` when calling `broccoli-plugin` constructor.
 
 All paths stay the same between builds.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Call this base class constructor from your subclass constructor.
       multiple instances of the same plugin apart.
     * `persistentOutput`: If true, the output directory is not automatically
       emptied between builds.
-    * `createCacheDirectory` : If `true`, a cache directory is created automatically
+    * `needsCache` : If `true`, a cache directory is created automatically
       and the path is set at `cachePath`. If `false`, a cache directory is not created
       and `this.cachePath` is `undefined`. Defaults to `true`.
 
@@ -70,7 +70,7 @@ This function will typically access the following read-only properties:
 * `this.cachePath`: The path on disk to an auxiliary cache directory. Use this
   to store files that you want preserved between builds. This directory will
   only be deleted when Broccoli exits. If a cache directory is not needed, set
-  `createCacheDirectory` to `false` when calling `broccoli-plugin` constructor.
+  `needsCache` to `false` when calling `broccoli-plugin` constructor.
 
 All paths stay the same between builds.
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ Plugin.prototype.__broccoliGetInfo__ = function(builderFeatures) {
   this.builderFeatures = this._checkBuilderFeatures(builderFeatures)
   if (!this._baseConstructorCalled) throw new Error('Plugin subclasses must call the superclass constructor: Plugin.call(this, inputNodes)')
 
-  return {
+  var nodeInfo = {
     nodeType: 'transform',
     inputNodes: this._inputNodes,
     setup: this._setup.bind(this),
@@ -67,6 +67,14 @@ Plugin.prototype.__broccoliGetInfo__ = function(builderFeatures) {
     persistentOutput: this._persistentOutput,
     createCacheDirectory: this._createCacheDirectory
   }
+
+  // Go backwards in time, removing properties from nodeInfo if they are not
+  // supported by the builder. Add new features at the top.
+  if (!this.builderFeatures.createCacheDirectoryFlag) {
+    delete nodeInfo.createCacheDirectory
+  }
+
+  return nodeInfo
 }
 
 Plugin.prototype._checkBuilderFeatures = function(builderFeatures) {

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Plugin(inputNodes, options) {
   this._baseConstructorCalled = true
   this._inputNodes = inputNodes
   this._persistentOutput = !!options.persistentOutput
+  this._createCacheDirectory = (options.createCacheDirectory != null) ? !!options.createCacheDirectory : true
 
   this._checkOverrides()
 }
@@ -46,12 +47,13 @@ Plugin.prototype._checkOverrides = function() {
 // For future extensibility, we version the API using feature flags
 Plugin.prototype.__broccoliFeatures__ = Object.freeze({
   persistentOutputFlag: true,
-  sourceDirectories: true
+  sourceDirectories: true,
+  createCacheDirectoryFlag: true
 })
 
 // The Broccoli builder calls plugin.__broccoliGetInfo__
 Plugin.prototype.__broccoliGetInfo__ = function(builderFeatures) {
-  builderFeatures = this._checkBuilderFeatures(builderFeatures)
+  this.builderFeatures = this._checkBuilderFeatures(builderFeatures)
   if (!this._baseConstructorCalled) throw new Error('Plugin subclasses must call the superclass constructor: Plugin.call(this, inputNodes)')
 
   return {
@@ -62,7 +64,8 @@ Plugin.prototype.__broccoliGetInfo__ = function(builderFeatures) {
     instantiationStack: this._instantiationStack,
     name: this._name,
     annotation: this._annotation,
-    persistentOutput: this._persistentOutput
+    persistentOutput: this._persistentOutput,
+    createCacheDirectory: this._createCacheDirectory
   }
 }
 
@@ -80,7 +83,11 @@ Plugin.prototype._setup = function(builderFeatures, options) {
   this._builderFeatures = builderFeatures
   this.inputPaths = options.inputPaths
   this.outputPath = options.outputPath
-  this.cachePath = options.cachePath
+  if (!this.builderFeatures.createCacheDirectoryFlag) {
+    this.cachePath = this._createCacheDirectory ? options.cachePath : undefined
+  } else {
+    this.cachePath = options.cachePath
+  }
 }
 
 Plugin.prototype.toString = function() {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function Plugin(inputNodes, options) {
   this._baseConstructorCalled = true
   this._inputNodes = inputNodes
   this._persistentOutput = !!options.persistentOutput
-  this._createCacheDirectory = (options.createCacheDirectory != null) ? !!options.createCacheDirectory : true
+  this._needsCache = (options.needsCache != null) ? !!options.needsCache : true
 
   this._checkOverrides()
 }
@@ -48,7 +48,7 @@ Plugin.prototype._checkOverrides = function() {
 Plugin.prototype.__broccoliFeatures__ = Object.freeze({
   persistentOutputFlag: true,
   sourceDirectories: true,
-  createCacheDirectoryFlag: true
+  needsCacheFlag: true
 })
 
 // The Broccoli builder calls plugin.__broccoliGetInfo__
@@ -65,13 +65,13 @@ Plugin.prototype.__broccoliGetInfo__ = function(builderFeatures) {
     name: this._name,
     annotation: this._annotation,
     persistentOutput: this._persistentOutput,
-    createCacheDirectory: this._createCacheDirectory
+    needsCache: this._needsCache
   }
 
   // Go backwards in time, removing properties from nodeInfo if they are not
   // supported by the builder. Add new features at the top.
-  if (!this.builderFeatures.createCacheDirectoryFlag) {
-    delete nodeInfo.createCacheDirectory
+  if (!this.builderFeatures.needsCacheFlag) {
+    delete nodeInfo.needsCache
   }
 
   return nodeInfo
@@ -91,8 +91,8 @@ Plugin.prototype._setup = function(builderFeatures, options) {
   this._builderFeatures = builderFeatures
   this.inputPaths = options.inputPaths
   this.outputPath = options.outputPath
-  if (!this.builderFeatures.createCacheDirectoryFlag) {
-    this.cachePath = this._createCacheDirectory ? options.cachePath : undefined
+  if (!this.builderFeatures.needsCacheFlag) {
+    this.cachePath = this._needsCache ? options.cachePath : undefined
   } else {
     this.cachePath = options.cachePath
   }

--- a/read_compat.js
+++ b/read_compat.js
@@ -16,7 +16,7 @@ function ReadCompat(plugin) {
 
   quickTemp.makeOrReuse(this, 'outputPath', this.pluginInterface.name)
 
-  if (this.pluginInterface.createCacheDirectory) {
+  if (this.pluginInterface.needsCache) {
     quickTemp.makeOrReuse(this, 'cachePath', this.pluginInterface.name)
   } else {
     this.cachePath = undefined

--- a/read_compat.js
+++ b/read_compat.js
@@ -8,7 +8,6 @@ var rimraf = require('rimraf')
 var symlinkOrCopy = require('symlink-or-copy')
 var symlinkOrCopySync = symlinkOrCopy.sync
 
-
 // Mimic how a Broccoli builder would call a plugin, using quickTemp to create
 // directories
 module.exports = ReadCompat
@@ -16,7 +15,13 @@ function ReadCompat(plugin) {
   this.pluginInterface = plugin.__broccoliGetInfo__()
 
   quickTemp.makeOrReuse(this, 'outputPath', this.pluginInterface.name)
-  quickTemp.makeOrReuse(this, 'cachePath', this.pluginInterface.name)
+
+  if (this.pluginInterface.createCacheDirectory) {
+    quickTemp.makeOrReuse(this, 'cachePath', this.pluginInterface.name)
+  } else {
+    this.cachePath = undefined
+  }
+
   quickTemp.makeOrReuse(this, 'inputBasePath', this.pluginInterface.name)
 
   this.inputPaths = []

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -309,7 +309,7 @@ describe('integration test', function(){
         })
       })
 
-      describe('createCacheDirectory', function() {
+      describe('needsCache', function() {
         function hasCacheDirectory(options) {
           var plugin = new NoopPlugin([], options)
           var builder = new Builder(plugin)
@@ -327,12 +327,12 @@ describe('integration test', function(){
           return expect(hasCacheDirectory()).to.eventually.equal(true)
         })
 
-        it('has no cache directory when createCacheDirectory is false', function() {
-          return expect(hasCacheDirectory({ createCacheDirectory: false })).to.eventually.equal(false)
+        it('has no cache directory when needsCache is false', function() {
+          return expect(hasCacheDirectory({ needsCache: false })).to.eventually.equal(false)
         })
 
-        it('has cache directory when createCacheDirectory is true', function() {
-          return expect(hasCacheDirectory({ createCacheDirectory: true })).to.eventually.equal(true)
+        it('has cache directory when needsCache is true', function() {
+          return expect(hasCacheDirectory({ needsCache: true })).to.eventually.equal(true)
         })
       })
     })

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -33,6 +33,13 @@ AnnotatingPlugin.prototype.build = function() {
   }
 }
 
+NoopPlugin.prototype = Object.create(Plugin.prototype)
+NoopPlugin.prototype.constructor = NoopPlugin
+function NoopPlugin() {
+  Plugin.apply(this, arguments)
+}
+NoopPlugin.prototype.build = function() {}
+
 
 
 describe('integration test', function(){
@@ -299,6 +306,33 @@ describe('integration test', function(){
 
         it('is persistent when persistentOutput is true', function() {
           return expect(isPersistent({ persistentOutput: true })).to.eventually.equal(true)
+        })
+      })
+
+      describe('createCacheDirectory', function() {
+        function hasCacheDirectory(options) {
+          var plugin = new NoopPlugin([], options)
+          var builder = new Builder(plugin)
+          return build(builder)
+            .then(function(outputPath) {
+              if (plugin.cachePath != null) {
+                expect(fs.existsSync(plugin.cachePath)).to.equal(true)
+              }
+              return plugin.cachePath != null
+            })
+            .finally(function() { builder.cleanup() })
+        }
+
+        it('has cache directory by default', function() {
+          return expect(hasCacheDirectory()).to.eventually.equal(true)
+        })
+
+        it('has no cache directory when createCacheDirectory is false', function() {
+          return expect(hasCacheDirectory({ createCacheDirectory: false })).to.eventually.equal(false)
+        })
+
+        it('has cache directory when createCacheDirectory is true', function() {
+          return expect(hasCacheDirectory({ createCacheDirectory: true })).to.eventually.equal(true)
         })
       })
     })

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -142,5 +142,50 @@ describe('unit tests', function() {
         expect(pluginInterface).to.have.property('createCacheDirectory', false)
       })
     })
+
+    describe('backwards compatibility', function() {
+      // All we're testing here is that old builder versions don't get
+      // properties that they don't support from __broccoliGetInfo__(). They
+      // typically won't care, so this is mostly for the sake of exactness.
+      //
+      // The main backwards compatiblity tests are not here but in the
+      // integration test suite, which tests against all Broccoli versions.
+
+      var node = new NoopPlugin([])
+
+      it('2 feature flags', function() {
+        expect(node.__broccoliGetInfo__({
+          persistentOutputFlag: true,
+          sourceDirectories: true
+        })).to.have.all.keys([
+          'nodeType',
+          'inputNodes',
+          'setup',
+          'getCallbackObject',
+          'instantiationStack',
+          'name',
+          'annotation',
+          'persistentOutput'
+        ])
+      })
+
+      it('3 feature flags', function() {
+        expect(node.__broccoliGetInfo__({
+          persistentOutputFlag: true,
+          sourceDirectories: true,
+          createCacheDirectoryFlag: true
+        })).to.have.all.keys([
+          'nodeType',
+          'inputNodes',
+          'setup',
+          'getCallbackObject',
+          'instantiationStack',
+          'name',
+          'annotation',
+          'persistentOutput',
+          'createCacheDirectory'
+        ])
+      })
+    })
   })
 })

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -97,48 +97,50 @@ describe('unit tests', function() {
   })
 
   describe('__broccoliGetInfo__', function() {
-    function expectCorrectInterface(pluginInterface) {
-      expect(pluginInterface).to.have.property('nodeType', 'transform')
-      expect(pluginInterface).to.have.property('inputNodes').that.deep.equals([])
-      expect(pluginInterface).to.have.property('persistentOutput', false)
-      expect(pluginInterface).to.have.property('name', 'NoopPlugin')
-      expect(pluginInterface).to.have.property('annotation', undefined)
-      expect(pluginInterface).to.have.property('createCacheDirectory', true)
+    describe('builderFeatures argument', function() {
+      function expectBasicInterface(pluginInterface) {
+        expect(pluginInterface).to.have.property('nodeType', 'transform')
+        expect(pluginInterface).to.have.property('inputNodes').that.deep.equals([])
+        expect(pluginInterface).to.have.property('persistentOutput', false)
+        expect(pluginInterface).to.have.property('name', 'NoopPlugin')
+        expect(pluginInterface).to.have.property('annotation', undefined)
 
-      expect(typeof pluginInterface.setup).to.equal('function')
-      expect(typeof pluginInterface.getCallbackObject).to.equal('function')
-      expect(typeof pluginInterface.instantiationStack).to.equal('string')
-    }
+        expect(typeof pluginInterface.setup).to.equal('function')
+        expect(typeof pluginInterface.getCallbackObject).to.equal('function')
+        expect(typeof pluginInterface.instantiationStack).to.equal('string')
+      }
 
-    it('returns a plugin interface with explicit feature flags', function() {
-      var node = new NoopPlugin([])
-      expectCorrectInterface(node.__broccoliGetInfo__({
-        persistentOutputFlag: true,
-        sourceDirectories: true
-      }))
-    })
-
-    it('sets createCacheDirectory if provided at instantiation`', function() {
-      var node = new NoopPlugin([], {
-        createCacheDirectory: false
+      it('returns a plugin interface with explicit feature flags', function() {
+        var node = new NoopPlugin([])
+        expectBasicInterface(node.__broccoliGetInfo__({
+          persistentOutputFlag: true,
+          sourceDirectories: true
+        }))
       })
 
-      var pluginInterface = node.__broccoliGetInfo__()
-      expect(pluginInterface).to.have.property('createCacheDirectory', false)
+      it('returns a plugin interface when no feature flags are given', function() {
+        var node = new NoopPlugin([])
+        expectBasicInterface(node.__broccoliGetInfo__())
+      })
+
+      it('throws an error when not passed enough feature flags', function() {
+        var node = new NoopPlugin([])
+        expect(function() {
+          // Pass empty features object, rather than missing (= default) argument
+          node.__broccoliGetInfo__({})
+        }).to.throw(/Minimum builderFeatures required/)
+      })
     })
 
+    describe('features', function() {
+      it('sets createCacheDirectory if provided at instantiation`', function() {
+        var node = new NoopPlugin([], {
+          createCacheDirectory: false
+        })
 
-    it('returns a plugin interface when no feature flags are given', function() {
-      var node = new NoopPlugin([])
-      expectCorrectInterface(node.__broccoliGetInfo__())
-    })
-
-    it('throws an error when not passed enough feature flags', function() {
-      var node = new NoopPlugin([])
-      expect(function() {
-        // Pass empty features object, rather than missing (= default) argument
-        node.__broccoliGetInfo__({})
-      }).to.throw(/Minimum builderFeatures required/)
+        var pluginInterface = node.__broccoliGetInfo__()
+        expect(pluginInterface).to.have.property('createCacheDirectory', false)
+      })
     })
   })
 })

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -103,6 +103,8 @@ describe('unit tests', function() {
       expect(pluginInterface).to.have.property('persistentOutput', false)
       expect(pluginInterface).to.have.property('name', 'NoopPlugin')
       expect(pluginInterface).to.have.property('annotation', undefined)
+      expect(pluginInterface).to.have.property('createCacheDirectory', true)
+
       expect(typeof pluginInterface.setup).to.equal('function')
       expect(typeof pluginInterface.getCallbackObject).to.equal('function')
       expect(typeof pluginInterface.instantiationStack).to.equal('string')
@@ -115,6 +117,16 @@ describe('unit tests', function() {
         sourceDirectories: true
       }))
     })
+
+    it('sets createCacheDirectory if provided at instantiation`', function() {
+      var node = new NoopPlugin([], {
+        createCacheDirectory: false
+      })
+
+      var pluginInterface = node.__broccoliGetInfo__()
+      expect(pluginInterface).to.have.property('createCacheDirectory', false)
+    })
+
 
     it('returns a plugin interface when no feature flags are given', function() {
       var node = new NoopPlugin([])

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -133,13 +133,13 @@ describe('unit tests', function() {
     })
 
     describe('features', function() {
-      it('sets createCacheDirectory if provided at instantiation`', function() {
+      it('sets needsCache if provided at instantiation`', function() {
         var node = new NoopPlugin([], {
-          createCacheDirectory: false
+          needsCache: false
         })
 
         var pluginInterface = node.__broccoliGetInfo__()
-        expect(pluginInterface).to.have.property('createCacheDirectory', false)
+        expect(pluginInterface).to.have.property('needsCache', false)
       })
     })
 
@@ -173,7 +173,7 @@ describe('unit tests', function() {
         expect(node.__broccoliGetInfo__({
           persistentOutputFlag: true,
           sourceDirectories: true,
-          createCacheDirectoryFlag: true
+          needsCacheFlag: true
         })).to.have.all.keys([
           'nodeType',
           'inputNodes',
@@ -183,7 +183,7 @@ describe('unit tests', function() {
           'name',
           'annotation',
           'persistentOutput',
-          'createCacheDirectory'
+          'needsCache'
         ])
       })
     })


### PR DESCRIPTION
Many plugins do not use the cache directory, this lets them opt out of its creation. By default, there is no change (cache directory is still created), but if the proper flags are passed to `broccoli-plugin` when calling `super` the directory can be avoided.

Making this change and utilizing from `broccoli-funnel` and `broccoli-merge-trees` eliminates ~ 231 extraneous directories during initial build of the Ghost admin app.

TODO:

- [x] Review consumer opt-in: https://github.com/broccolijs/broccoli-funnel/pull/85 & https://github.com/broccolijs/broccoli-merge-trees/pull/56
- [x] Review https://github.com/broccolijs/broccoli/pull/313 to support this when not using the read compat API.
- [x] Review https://github.com/broccolijs/broccoli-node-info/pull/1 
- [x] Update documentation.
