### PR TITLE
Avoid extra work when input nodes have stable output paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "promise-map-series": "^0.2.1",
     "quick-temp": "^0.1.3",
     "rimraf": "^2.3.4",
-    "symlink-or-copy": "^1.0.1"
+    "symlink-or-copy": "^1.1.8"
   },
   "devDependencies": {
     "broccoli-fixturify": "^0.2.0",

--- a/read_compat.js
+++ b/read_compat.js
@@ -5,7 +5,8 @@ var path = require('path')
 var quickTemp = require('quick-temp')
 var mapSeries = require('promise-map-series')
 var rimraf = require('rimraf')
-var symlinkOrCopySync = require('symlink-or-copy').sync
+var symlinkOrCopy = require('symlink-or-copy')
+var symlinkOrCopySync = symlinkOrCopy.sync
 
 
 // Mimic how a Broccoli builder would call a plugin, using quickTemp to create
@@ -19,9 +20,11 @@ function ReadCompat(plugin) {
   quickTemp.makeOrReuse(this, 'inputBasePath', this.pluginInterface.name)
 
   this.inputPaths = []
+  this._priorBuildInputNodeOutputPaths = [];
 
   if (this.pluginInterface.inputNodes.length === 1) {
     this.inputPaths.push(this.inputBasePath)
+    this._priorBuildInputNodeOutputPaths.push(this.inputBasePath);
   } else {
     for (var i = 0; i < this.pluginInterface.inputNodes.length; i++) {
       this.inputPaths.push(path.join(this.inputBasePath, i + ''))
@@ -54,14 +57,33 @@ ReadCompat.prototype.read = function(readTree) {
 
   return mapSeries(this.pluginInterface.inputNodes, readTree)
     .then(function(outputPaths) {
+      var priorBuildInputNodeOutputPaths = self._priorBuildInputNodeOutputPaths;
       // In old .read-based Broccoli, the inputNodes's outputPaths can change
       // on each rebuild. But the new API requires that our plugin sees fixed
       // input paths. Therefore, we symlink the inputNodes' outputPaths to our
       // (fixed) inputPaths on each .read.
       for (var i = 0; i < outputPaths.length; i++) {
-        rimraf.sync(self.inputPaths[i]) // this is no-op if path does not exist
-        symlinkOrCopySync(outputPaths[i], self.inputPaths[i])
+        var priorPath = priorBuildInputNodeOutputPaths[i]
+        var currentPath = outputPaths[i]
+
+        // if this output path is different from last builds or
+        // if we cannot symlink then clear and symlink/copy manually
+        var hasDifferentPath = priorPath !== currentPath
+        var forceReSymlinking = !symlinkOrCopy.canSymlink || hasDifferentPath
+
+        if (forceReSymlinking) {
+
+          // avoid `rimraf.sync` for initial build
+          if (priorPath) {
+            rimraf.sync(self.inputPaths[i])
+          }
+
+          symlinkOrCopySync(currentPath, self.inputPaths[i])
+        }
       }
+
+      // save for next builds comparison
+      self._priorBuildInputNodeOutputPaths = outputPaths;
 
       return self.callbackObject.build()
     })


### PR DESCRIPTION
In most cases, the output paths are actually stable. This changes things around a bit to make this compatibility layer a tad bit more "pay as you go", by only doing the extra work of clearing and re-symlinking the `inputPaths` when it is needed.

This cuts down on at least 4 filesystem operations per node:

1. `fs.lstatSync` done by `rimraf.sync` to determine how to remove prior inputPath
2. `fs.unlinkSync` done by `rimraf.sync` to remove old inputPath
3. `fs.lstatSync` done by `symlink-or-copy` to dereference source symlinks
4. `fs.symlinkSync` done by `symlink-or-copy`

Prior to the changes in this PR the above 4 steps would be done on **every** tree in the entire system for every build and rebuild. After these changes, the above steps are only executed for initial builds and when the input paths actually need to change.