### PR TITLE
Update to test on current supported node versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
-  - "iojs-v1.0.0"
-  - "node"
+  - "4"
+  - "6"
+  - "stable"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
+    - nodejs_version: "4"
+    - nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
This updates to test on the following:

* 0.12 (LTS expires 2016-12-31)
* 4 (LTS expires 2018-04-01
* 6 (LTS expires 2019-04-18)