### PR TITLE
Prevent arrays from masquerading as a node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,19 @@ Plugin.prototype._initializeReadCompat = function() {
 }
 
 function isPossibleNode(node) {
-  return typeof node === 'string' ||
-    (node !== null && typeof node === 'object')
+  var type = typeof node;
+
+  if (node === null) {
+    return false;
+  } else if (type === 'string') {
+    return true;
+  } else if (type === 'object' && typeof node.__broccoliGetInfo__ === 'function') {
+    // Broccoli 1.x+
+    return true;
+  } else if (type === 'object' && typeof node.read === 'function') {
+    // Broccoli / broccoli-builder <= 0.18
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -63,6 +63,10 @@ describe('unit tests', function() {
         new TestPlugin([true])
       }).to.throw(TypeError, 'TestPlugin: Expected Broccoli node, got true for inputNodes[0]')
 
+      expect(function() {
+        new TestPlugin([ [] ])
+      }).to.throw(TypeError, /TestPlugin: Expected Broccoli node/)
+
       // Expect not to throw
       new TestPlugin([])
       new TestPlugin(['some/path'])


### PR DESCRIPTION
The prior validation logic mishandled `Array.isArray` (because `typeof []` returns `"object"`). This corrects that gap...

Closes https://github.com/broccolijs/broccoli-merge-trees/issues/63.