### PR TITLE
Make this.inputPaths and this.outputPaths accessors

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const broccoliFeatures = Object.freeze({
   needsCacheFlag: true,
   volatileFlag: true,
 });
+const PATHS = new WeakMap();
 
 function isPossibleNode(node) {
   let type = typeof node;
@@ -63,6 +64,26 @@ module.exports = class Plugin {
 
     // For future extensibility, we version the API using feature flags
     this.__broccoliFeatures__ = broccoliFeatures;
+  }
+
+  get inputPaths() {
+    if (!PATHS.has(this)) {
+      throw new Error(
+        'BroccoliPlugin: this.inputPaths is only accessible once the build has begun.'
+      );
+    }
+
+    return PATHS.get(this).inputPaths;
+  }
+
+  get outputPath() {
+    if (!PATHS.has(this)) {
+      throw new Error(
+        'BroccoliPlugin: this.outputPath is only accessible once the build has begun.'
+      );
+    }
+
+    return PATHS.get(this).outputPath;
   }
 
   _checkOverrides() {
@@ -125,8 +146,12 @@ module.exports = class Plugin {
   _setup(builderFeatures, options) {
     builderFeatures = this._checkBuilderFeatures(builderFeatures);
     this._builderFeatures = builderFeatures;
-    this.inputPaths = options.inputPaths;
-    this.outputPath = options.outputPath;
+
+    PATHS.set(this, {
+      inputPaths: options.inputPaths,
+      outputPath: options.outputPath,
+    });
+
     if (!this.builderFeatures.needsCacheFlag) {
       this.cachePath = this._needsCache ? options.cachePath : undefined;
     } else {

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -88,6 +88,35 @@ describe('unit tests', function() {
         new NoopPlugin('notAnArray');
       }).to.throw(/Expected an array/);
     });
+
+    it('throws runtime exceptions if inputPaths/outputPath are accessed prematurily', function() {
+      expect(function() {
+        new class extends Plugin {
+          constructor(...args) {
+            super(...args);
+            this.inputPaths;
+          }
+        }([]);
+      }).to.throw(/BroccoliPlugin: this.inputPaths is only accessible once the build has begun./);
+
+      expect(function() {
+        new class extends Plugin {
+          constructor(...args) {
+            super(...args);
+            this.outputPath;
+          }
+        }([]);
+      }).to.throw(/BroccoliPlugin: this.outputPath is only accessible once the build has begun./);
+
+      class Other extends Plugin {}
+      const subject = new Other([]);
+      expect(() => subject.inputPaths).to.throw(
+        /BroccoliPlugin: this.inputPaths is only accessible once the build has begun./
+      );
+      expect(() => subject.outputPath).to.throw(
+        /BroccoliPlugin: this.outputPath is only accessible once the build has begun./
+      );
+    });
   });
 
   describe('__broccoliGetInfo__', function() {


### PR DESCRIPTION
Make this.inputPaths and this.outputPaths accessors

* they are now readOnly
* if accessed prematurely they will throw a helpful runtime error. Prematurely is consider anytime before the broccoli builder has initialized them, in-practice for plugin authors this only means in the constructor.
* TS typings are simpler, and all valid use cases of this.outputPath + this.inputPaths usage no longer need to be guarded or use `!`

- [x] make work
- [x] write tests
- [x] get feedback