### PR TITLE
cleanup feature capability code

### DIFF
--- a/read_compat.js
+++ b/read_compat.js
@@ -8,11 +8,19 @@ const rimraf = require('rimraf');
 const symlinkOrCopy = require('symlink-or-copy');
 const symlinkOrCopySync = symlinkOrCopy.sync;
 
+const READ_COMPAT_FEATURES = Object.freeze({
+  // these two features are supported by the old builders which still utilize read()
+  persistentOutputFlag: true,
+  sourceDirectories: true,
+  // ReadCompat provides this capability as the builder relying on ReadCompat may not
+  needsCacheFlag: true,
+});
+
 // Mimic how a Broccoli builder would call a plugin, using quickTemp to create
 // directories
 module.exports = ReadCompat;
 function ReadCompat(plugin) {
-  this.pluginInterface = plugin.__broccoliGetInfo__();
+  this.pluginInterface = plugin.__broccoliGetInfo__(READ_COMPAT_FEATURES);
 
   quickTemp.makeOrReuse(this, 'outputPath', this.pluginInterface.name);
 
@@ -36,7 +44,7 @@ function ReadCompat(plugin) {
     }
   }
 
-  this.pluginInterface.setup(null, {
+  this.pluginInterface.setup(READ_COMPAT_FEATURES, {
     inputPaths: this.inputPaths,
     outputPath: this.outputPath,
     cachePath: this.cachePath,

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -145,8 +145,9 @@ describe('unit tests', function() {
         );
       });
 
-      it('returns a plugin interface when no feature flags are given', function() {
+      it('defaults to the default featureset if no features are provided', function() {
         let node = new NoopPlugin([]);
+
         expectBasicInterface(node.__broccoliGetInfo__());
       });
 
@@ -155,7 +156,7 @@ describe('unit tests', function() {
         expect(function() {
           // Pass empty features object, rather than missing (= default) argument
           node.__broccoliGetInfo__({});
-        }).to.throw(/Minimum builderFeatures required/);
+        }).to.throw(/Minimum builderFeatures not met/);
       });
     });
 
@@ -165,8 +166,25 @@ describe('unit tests', function() {
           needsCache: false,
         });
 
-        let pluginInterface = node.__broccoliGetInfo__();
-        expect(pluginInterface).to.have.property('needsCache', false);
+        {
+          // legacy builder
+          let pluginInterface = node.__broccoliGetInfo__({
+            persistentOutputFlag: true,
+            sourceDirectories: true,
+          });
+          expect(pluginInterface).to.not.have.property('needsCache');
+        }
+
+        {
+          // normal modern builder
+          let pluginInterface = node.__broccoliGetInfo__({
+            persistentOutputFlag: true,
+            sourceDirectories: true,
+            needsCacheFlag: true,
+          });
+
+          expect(pluginInterface).to.have.property('needsCache', false);
+        }
       });
     });
 


### PR DESCRIPTION
Tighten-up feature capability code. Largely to keep the typescript types of this project (and docs) better aligned with the actual implementation.

* decouple readCompat features from builderFeatures and broccoli_features  (ensure the correct capabilities are provided per given context)
* don’t store builderFeatures on the plugin instance
* never allow passing null to pluginInterface.setup (always pass the broccoli features)
* improve the error message for if features are not met slightly
* always expect FEATURES to be provided to `__broccoliGetInfo__` (@rwjblue if this is too strict, we can default it to the minimum features, but if we can keep it strict the would be ideal)

- [x] fix last two failing tests
- [x] etc.

Paired with @krisselden and @thoov 