### PR TITLE
Add the input/output facade to provide easy access to file operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,74 @@ may have the following optional properties in addition to the standard
   `this.inputPaths`. (The name `treeDir` is for historical reasons.)
 - `line`: Line in which the error occurred (one-indexed)
 - `column`: Column in which the error occurred (zero-indexed)
+
+### `Plugin.prototype.input`
+
+Plugin now provides a easy way to read from input path via `Plugin.prototype.input`. `input` provides file operation methods to read file, directory etc. `input` automatically attaches the corresponding inputpath to the filename. `input` searches the filename from left to right and the right most file takes the precedance if there are two files exists with same path from the root in different inputpaths.
+Ex:
+
+```js
+/* test-1
+    |
+    -- a.txt
+    -- b.txt
+
+    test-2
+    |
+    -- c.txt
+    -- d.txt
+    -- sub-dir
+        |
+        -- x.txt
+        -- y.txt
+
+    test-3
+    |
+    -- e.txt
+    -- a.txt
+ */
+const Plugin = require('broccoli-plugin');
+
+class MyPlugin extends Plugin {
+  constructor(inputNodes, options = {}) {
+    super(inputNodes);
+  }
+
+  build() {
+    //below a.txt will the file from path `test-3/a.txt`
+    const input = this.input.readFileSync(`a.txt`);
+    // To access the file from a specific inputPath, ex: to access `this.inputPaths[0]`, we can use `at` method.
+    const content = this.input.at(0).readFileSync('a.txt');
+  }
+}
+```
+
+Read more about `input` [here](https://github.com/SparshithNR/fs-merger#fsmergerfs)
+
+Note: `input` will be available only after the `build` starts.
+
+### `Plugin.prototype.output`
+
+Plugin now provides a easy way to write to the output path via `Plugin.prototype.output`. `output` provides file operation methods to write file, create/remove directory etc. It automatically attaches the outputpath to the filename.
+Ex:
+
+```js
+const Plugin = require('broccoli-plugin');
+
+class MyPlugin extends Plugin {
+  constructor(inputNodes, options = {}) {
+    super(inputNodes);
+  }
+
+  build() {
+    const input = this.input.readFileSync('a.txt');
+    const output = someCompiler(input);
+    // this.outputPath will be attched to the output file name.
+    this.output.writeFileSync('complied.txt');
+  }
+}
+```
+
+Read more about APIs present in `output` [here](https://github.com/SparshithNR/broccoli-output-wrapper#apis).
+
+Note: `output` will be available only after the `build` starts.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ class MyPlugin extends Plugin {
     // Silly example:
 
     // Read 'foo.txt' from the third input node
-    const input = fs.readFileSync(`${this.inputPaths[2]}/foo.txt`);
+    const input = this.input.readFileSync(`foo.txt`);
     const output = someCompiler(input);
 
     // Write to 'bar.txt' in this node's output
-    fs.writeFileSync(`${this.outputPath}/bar.txt`, output);
+    this.output.writeFileSync(`bar.txt`, output);
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -124,44 +124,41 @@ may have the following optional properties in addition to the standard
 
 ### `Plugin.prototype.input`
 
-Plugin now provides a easy way to read from input path via `Plugin.prototype.input`. `input` provides file operation methods to read file, directory etc. `input` automatically attaches the corresponding inputpath to the filename. `input` searches the filename from left to right and the right most file takes the precedance if there are two files exists with same path from the root in different inputpaths.
-Ex:
+An api which enables a plugin to easily read from one or more input directories ergonomically and safely.
+
+_Note: We recommend users stop using this.inputPaths and instead rely on this.input. Our plan at present is to strongly consider deprecation of this.inputPaths once this.input has had time to bake._
+
+this.input's features:
+
+- `this.input` reads from the provided `inputPaths`. No path concatenation required.
+- `this.input` provides readOnly file system APIs. This prevents a plugin from erroneously mutating its inputs.
+- `this.input` provides a merged view of inputs, this allows every plugin to easily support multiple inputs, without the use of `broccoli-merge-trees` or implementing a complex merge algorithm.
+- `this.input.at(index)` provides access to each individual input if desired.
+
+Example:
 
 ```js
-/* test-1
-    |
-    -- a.txt
-    -- b.txt
+// old
+fs.readFileSync(this.inputPaths[0] + '/file.txt');
 
-    test-2
-    |
-    -- c.txt
-    -- d.txt
-    -- sub-dir
-        |
-        -- x.txt
-        -- y.txt
+// new (merged): Most Common
+this.input.readFileSync('file.txt');
 
-    test-3
-    |
-    -- e.txt
-    -- a.txt
- */
-const Plugin = require('broccoli-plugin');
+// new (indexed): For when you need to disambiguate between inputs.
+this.input.at(0).readFileSync('file.txt);
 
-class MyPlugin extends Plugin {
-  constructor(inputNodes, options = {}) {
-    super(inputNodes);
-  }
-
-  build() {
-    //below a.txt will the file from path `test-3/a.txt`
-    const input = this.input.readFileSync(`a.txt`);
-    // To access the file from a specific inputPath, ex: to access `this.inputPaths[0]`, we can use `at` method.
-    const content = this.input.at(0).readFileSync('a.txt');
-  }
-}
+// ReadOnly
+this.input.writeFileSync // throws error
 ```
+
+### List of Methods
+
+- readFileSync
+- existsSync
+- lstatSync
+- statSync
+- readdirSync
+- at
 
 Read more about `input` [here](https://github.com/SparshithNR/fs-merger#fsmergerfs)
 
@@ -169,25 +166,36 @@ Note: `input` will be available only after the `build` starts.
 
 ### `Plugin.prototype.output`
 
-Plugin now provides a easy way to write to the output path via `Plugin.prototype.output`. `output` provides file operation methods to write file, create/remove directory etc. It automatically attaches the outputpath to the filename.
+An api which enables a plugin to easily write to the output directory ergonomically and safely.
+
+_Note: We recommend users stop using this.outputPath and instead rely on this.output. Our plan at present is to strongly consider deprecation of this.outputPath once this.output has had time to bake._
+
+this.output's features:
+
+- `this.ouput` writes to the `outputPath`. No path concatenation required.
+- `this.output` provides read operations on the `outputPath`. No path concatenation required.
+
 Ex:
 
 ```js
-const Plugin = require('broccoli-plugin');
+// old
+fs.writeFileSync(this.outputPath + '/file.txt', 'text');
 
-class MyPlugin extends Plugin {
-  constructor(inputNodes, options = {}) {
-    super(inputNodes);
-  }
-
-  build() {
-    const input = this.input.readFileSync('a.txt');
-    const output = someCompiler(input);
-    // this.outputPath will be attched to the output file name.
-    this.output.writeFileSync('complied.txt');
-  }
-}
+// new
+this.output.writeFileSync('file.txt', 'text');
 ```
+
+### List of Methods
+
+- readFileSync
+- existsSync
+- lstatSync
+- readdirSync
+- statSync
+- writeFileSync
+- appendFileSync
+- rmdirSync
+- mkdirSync
 
 Read more about APIs present in `output` [here](https://github.com/SparshithNR/broccoli-output-wrapper#apis).
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "broccoli-node-api": "^1.6.0",
     "broccoli-output-wrapper": "^2.0.0",
-    "fs-merger": "^3.0.0",
+    "fs-merger": "^3.0.1",
     "promise-map-series": "^0.2.1",
     "quick-temp": "^0.1.3",
     "rimraf": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "dependencies": {
     "broccoli-node-api": "^1.6.0",
+    "broccoli-output-wrapper": "^2.0.0",
+    "fs-merger": "^3.0.0",
     "promise-map-series": "^0.2.1",
     "quick-temp": "^0.1.3",
     "rimraf": "^2.3.4",
@@ -52,7 +54,7 @@
     "prettier": "^1.16.4",
     "pretty-quick": "^1.11.1",
     "rsvp": "^4.8.4",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.4"
   },
   "engines": {
     "node": "8.* || 10.* || >= 12.*"

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -258,19 +258,23 @@ describe('integration test', function() {
 
       describe('persistent output', function() {
         class BuildOnce extends Plugin {
+          constructor(node, options = {}) {
+            super(node, options);
+          }
           build() {
             if (!this.builtOnce) {
               this.builtOnce = true;
-              fs.writeFileSync(path.join(this.outputPath, 'foo.txt'), 'test');
+              this.output.writeFileSync('foo.txt', 'test');
             }
           }
         }
 
         function isPersistent(options) {
-          let builder = new Builder(new BuildOnce([], options));
+          let buildOnce = new BuildOnce([], options);
+          let builder = new Builder(buildOnce);
           function buildAndCheckExistence() {
-            return build(builder).then(function(outputPath) {
-              return fs.existsSync(path.join(outputPath, 'foo.txt'));
+            return build(builder).then(function() {
+              return buildOnce.output.existsSync('foo.txt');
             });
           }
           return expect(buildAndCheckExistence())

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -228,6 +228,69 @@ describe('integration test', function() {
     });
   });
 
+  describe('.input/.output functionality', function() {
+    let Builder = multidepRequire('broccoli', '0.16.9').Builder;
+    class FSFacadePlugin extends Plugin {
+      build() {
+        let content = this.input.readFileSync('foo.txt', 'utf-8');
+        this.output.writeFileSync('complied.txt', content);
+      }
+    }
+
+    it('reads file using this.input', function() {
+      let node = new FSFacadePlugin([node1, node2]);
+      builder = new Builder(node);
+      return builder.build().then(function() {
+        return expect(node.input.readFileSync('foo.txt', 'utf-8')).to.equal('foo contents');
+      });
+    });
+
+    it('reads file using this.input', function() {
+      let node = new FSFacadePlugin([node1, node2]);
+      builder = new Builder(node);
+      return builder.build().then(function() {
+        return expect(node.input.at(1).readFileSync('bar.txt', 'utf-8')).to.equal('bar contents');
+      });
+    });
+
+    it('writes file using this.output', function() {
+      let node = new FSFacadePlugin([node1, node2]);
+      builder = new Builder(node);
+      return builder.build().then(function() {
+        return expect(node.output.readFileSync('complied.txt', 'utf-8')).to.equal('foo contents');
+      });
+    });
+
+    it('verify few operations we expect are present in input', function() {
+      let node = new FSFacadePlugin([node1, node2]);
+      builder = new Builder(node);
+      return builder.build().then(function() {
+        expect(typeof node.input.readFileSync == 'function').to.be.true;
+        expect(typeof node.input.readdirSync == 'function').to.be.true;
+        expect(typeof node.input.at == 'function').to.be.true;
+        expect(() => {
+          node.input.writeFileSync('read.md', 'test');
+        }).to.throw(/Operation writeFileSync is not allowed .*/);
+      });
+    });
+
+    it('verify few operations we expect are present in output', function() {
+      let node = new FSFacadePlugin([node1, node2]);
+      builder = new Builder(node);
+      return builder.build().then(function() {
+        expect(typeof node.output.readFileSync == 'function').to.be.true;
+        expect(typeof node.output.readdirSync == 'function').to.be.true;
+        expect(typeof node.output.existSync == 'function').to.be.true;
+        expect(typeof node.output.writeFileSync == 'function').to.be.true;
+        expect(typeof node.output.rmdirSync == 'function').to.be.true;
+        expect(typeof node.output.mkdirSync == 'function').to.be.true;
+        expect(() => {
+          node.output.readFileMeta('test.txt');
+        }).to.throw(/Operation readFileMeta is not allowed .*/);
+      });
+    });
+  });
+
   multidepRequire.forEachVersion('broccoli', function(broccoliVersion, module) {
     let Builder = module.Builder;
 

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -115,6 +115,35 @@ describe('unit tests', function() {
         /BroccoliPlugin: this.outputPath is only accessible once the build has begun./
       );
     });
+
+    it('throws runtime exceptions if input/output are accessed prematurily', function() {
+      expect(function() {
+        new class extends Plugin {
+          constructor(...args) {
+            super(...args);
+            this.input;
+          }
+        }([]);
+      }).to.throw(/BroccoliPlugin: this.input is only accessible once the build has begun./);
+
+      expect(function() {
+        new class extends Plugin {
+          constructor(...args) {
+            super(...args);
+            this.output;
+          }
+        }([]);
+      }).to.throw(/BroccoliPlugin: this.output is only accessible once the build has begun./);
+
+      class Other extends Plugin {}
+      const subject = new Other([]);
+      expect(() => subject.input).to.throw(
+        /BroccoliPlugin: this.input is only accessible once the build has begun./
+      );
+      expect(() => subject.output).to.throw(
+        /BroccoliPlugin: this.output is only accessible once the build has begun./
+      );
+    });
   });
 
   describe('__broccoliGetInfo__', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,10 +707,10 @@ fs-extra@^8.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-merger@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.0.0.tgz#f1f7dd5bd59e8758ba6158fc2943f1bb3c42fc6d"
-  integrity sha512-xBMYI3WMoOq1/+gXKwV9m5XH/jtHqJlbRpp/5SaPhQsjpDcJaunRXAbnlf6AzGUEPOlxvalL8dLl+xAqaMnUBg==
+fs-merger@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.0.1.tgz#4fba891e1ac83ce1ea4261b91fee475aaf628cb2"
+  integrity sha512-0DDF7GDMm4roej5N6Z7ZNC2y2VdZdYQtHm32wWluSONyxUMqIAWyD73v0S12GkqO416BGqSHr2tjU4hmIlbylw==
   dependencies:
     broccoli-node-api "^1.7.0"
     broccoli-node-info "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -210,10 +210,22 @@ broccoli-fixturify@^0.3.0:
     broccoli-plugin "^1.2.0"
     fixturify "~0.3.0"
 
-broccoli-node-api@^1.6.0:
+broccoli-node-api@^1.6.0, broccoli-node-api@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/broccoli-node-api/-/broccoli-node-api-1.7.0.tgz#391aa6edecd2a42c63c111b4162956b2fa288cb6"
   integrity sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==
+
+broccoli-node-info@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz#ca84560e8570ff78565bea1699866ddbf58ad644"
+  integrity sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==
+
+broccoli-output-wrapper@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz#f1e0b9b2f259a67fd41a380141c3c20b096828e6"
+  integrity sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==
+  dependencies:
+    heimdalljs-logger "^0.1.10"
 
 broccoli-plugin@^1.2.0:
   version "1.3.0"
@@ -360,6 +372,13 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -400,6 +419,11 @@ end-of-stream@^1.1.0:
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
   dependencies:
     once "^1.4.0"
+
+ensure-posix-path@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz#3c62bdb19fa4681544289edb2b382adc029179ce"
+  integrity sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -674,6 +698,38 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-merger@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.0.0.tgz#f1f7dd5bd59e8758ba6158fc2943f1bb3c42fc6d"
+  integrity sha512-xBMYI3WMoOq1/+gXKwV9m5XH/jtHqJlbRpp/5SaPhQsjpDcJaunRXAbnlf6AzGUEPOlxvalL8dLl+xAqaMnUBg==
+  dependencies:
+    broccoli-node-api "^1.7.0"
+    broccoli-node-info "^2.1.0"
+    fs-extra "^8.0.1"
+    fs-tree-diff "^2.0.1"
+    rimraf "^2.6.3"
+    walk-sync "^2.0.2"
+
+fs-tree-diff@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz#343e4745ab435ec39ebac5f9059ad919cd034afa"
+  integrity sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==
+  dependencies:
+    "@types/symlink-or-copy" "^1.2.0"
+    heimdalljs-logger "^0.1.7"
+    object-assign "^4.1.0"
+    path-posix "^1.0.0"
+    symlink-or-copy "^1.1.8"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -741,6 +797,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graceful-fs@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -752,6 +813,21 @@ has-flag@^3.0.0:
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+heimdalljs-logger@^0.1.10, heimdalljs-logger@^0.1.7:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz#90cad58aabb1590a3c7e640ddc6a4cd3a43faaf7"
+  integrity sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==
+  dependencies:
+    debug "^2.2.0"
+    heimdalljs "^0.2.6"
+
+heimdalljs@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.6.tgz#b0eebabc412813aeb9542f9cc622cb58dbdcd9fe"
+  integrity sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==
+  dependencies:
+    rsvp "~3.2.1"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -926,6 +1002,13 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -982,6 +1065,14 @@ matcher-collection@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.5.tgz#2ee095438372cb8884f058234138c05c644ec339"
   dependencies:
+    minimatch "^3.0.2"
+
+matcher-collection@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-2.0.1.tgz#90be1a4cf58d6f2949864f65bb3b0f3e41303b29"
+  integrity sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
     minimatch "^3.0.2"
 
 mimic-fn@^1.0.0:
@@ -1088,6 +1179,11 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1220,6 +1316,11 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-posix@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-posix/-/path-posix-1.0.0.tgz#06b26113f56beab042545a23bfa88003ccac260f"
+  integrity sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=
 
 pathval@^1.0.0:
   version "1.1.0"
@@ -1370,6 +1471,13 @@ rimraf@^2.2.8, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.5.4:
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rsvp@^3.0.14, rsvp@^3.1.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
@@ -1378,6 +1486,11 @@ rsvp@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
   integrity sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==
+
+rsvp@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
+  integrity sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -1611,10 +1724,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
 underscore.string@~3.3.4:
   version "3.3.4"
@@ -1622,6 +1735,11 @@ underscore.string@~3.3.4:
   dependencies:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -1641,6 +1759,15 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+walk-sync@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-2.0.2.tgz#5ea8a28377c8be68c92d50f4007ea381725da14b"
+  integrity sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    ensure-posix-path "^1.1.0"
+    matcher-collection "^2.0.0"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
1. Provide an easy interface to read and write files via input/output
2. Make sure input/output are immutable
3. They can be accessed once the build began
4. Add unit test
5. Modify integration test to use input.readFileSync
6. Update README.md