### PR TITLE
Bump broccoli-output-wrapper to v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "broccoli-node-api": "^1.6.0",
-    "broccoli-output-wrapper": "^3.1.1",
+    "broccoli-output-wrapper": "^3.2.1",
     "fs-merger": "^3.0.1",
     "promise-map-series": "^0.2.1",
     "quick-temp": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,10 +272,10 @@ broccoli-node-info@^2.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz#ca84560e8570ff78565bea1699866ddbf58ad644"
   integrity sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==
 
-broccoli-output-wrapper@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-3.1.1.tgz#d5f2c04b1259fd1df72e4d9951df2d23f202d301"
-  integrity sha512-iIA5EJ7jmG7rmAFerJ1Fi57L7NICN6ErVhw8ClLDVBrLQYXK0uWicwXL2/2HWlGIL0oFFrIiw+/W0BNVib6DSA==
+broccoli-output-wrapper@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.1.tgz#8f9d1092afe0c1a4b7a1b6f0d2c62f1c403e82ad"
+  integrity sha512-mhOTy8AyzEsqgefR2ejbv5QTy3dbY2bvDfkARo55Xml52r2MU0CehQu4T/CH6oPcAXkdVYG/hGm9UpV1vU9Ohg==
   dependencies:
     fs-extra "^8.1.0"
     heimdalljs-logger "^0.1.10"


### PR DESCRIPTION
Require a minimum version of `broccoli-output-wrapper` with `outputFileSync()` (https://github.com/SparshithNR/broccoli-output-wrapper/pull/10). This way plugins that use `outputFileSync()` such as `broccoli-concat` will be guaranteed to have a version of `broccoli-output-wrapper` in which it's implemented.