### PR TITLE
Revert "Prepare Release v6.0.0 using 'release-plan'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## Release (2026-07-10)
-
-* broccoli-plugin 6.0.0 (major)
-
-#### :boom: Breaking Change
-* `broccoli-plugin`
-  * [#82](https://github.com/broccolijs/broccoli-plugin/pull/82) drop support for ancient broccoli version - only support broccoli >= 1.0.0 ([@mansona](https://github.com/mansona))
-
-#### Committers: 1
-- Chris Manson ([@mansona](https://github.com/mansona))
-
 ## Release (2026-02-24)
 
 * broccoli-plugin 5.0.0 (major)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-plugin",
-  "version": "6.0.0",
+  "version": "5.0.0",
   "description": "Base class for all Broccoli plugins",
   "keywords": [
     "broccoli-plugin"


### PR DESCRIPTION
This reverts #83 because release-plan is broken (or rather npm still hasn't fixed the self-update bug 😫) 